### PR TITLE
Make usage of output_dir consistent with cookiecutter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ of the parameters to set::
 With **pieceofcake**, the user is shown a series of verbose questions which provide
 more context as to the meaning/implications of each parameter::
 
-    % cookiecutter gh:astrofrog/fake-template final-package
+    % cookiecutter gh:astrofrog/fake-template output_dir
 
     Welcome to the pieceofcake, a user-friendly cookiecutter wrapper!
 
@@ -33,7 +33,7 @@ more context as to the meaning/implications of each parameter::
 
     Running cookiecutter...
 
-    You should now be all set! Your generated package is in final-package
+    You should now be all set! Your generated package is in output_dir
 
 Installing
 ==========
@@ -47,11 +47,12 @@ Using
 
 To use **pieceofcake**::
 
-    pieceofcake template output_directory
+    pieceofcake template output_dir
 
 where ``template`` follows the same syntax as for cookiecutter, and can be
-the path to a local directory, or e.g. gh:astrofrog/fake-template to use
-a GitHub repository.
+the path to a local directory, or e.g. ``gh:astrofrog/fake-template`` to use
+a GitHub repository.  The new package will be created as a subdirectory of
+``output_dir``.
 
 Note that ``pieceofcake`` will work with all cookiecutter templates, but
 nice questions will only be shown if the ``cookiecutter.json`` file contains

--- a/pieceofcake/__init__.py
+++ b/pieceofcake/__init__.py
@@ -1,1 +1,1 @@
-from .version import version as __version__
+#from .version import version as __version__

--- a/pieceofcake/__init__.py
+++ b/pieceofcake/__init__.py
@@ -1,1 +1,1 @@
-#from .version import version as __version__
+from .version import version as __version__

--- a/pieceofcake/main.py
+++ b/pieceofcake/main.py
@@ -46,15 +46,6 @@ def main(template, output_dir, checkout):
     print("your package.")
     print("")
 
-    if os.path.exists(output_dir):
-        if click.prompt(f'It looks like {output_dir} already exists. Can we safely remove it? (y/n)', type=str, default='n') == 'y':
-            shutil.rmtree(output_dir)
-            print("")
-        else:
-            print("Aborting...")
-            sys.exit(0)
-            pass
-
     parameters = cjson.get('_parameters')
 
     values = {}
@@ -102,13 +93,12 @@ def main(template, output_dir, checkout):
 
         print("")
 
-    os.mkdir(output_dir)
-
     with open(os.path.join(tmpdir, 'cookiecutter.json'), 'w') as fout:
         json.dump(values, fout, indent='  ')
 
     print(tmpdir)
     print("Running cookiecutter...")
+
     cookiecutter(tmpdir, output_dir=output_dir, no_input=True)
 
     print("")


### PR DESCRIPTION
When I was running pieceofcake, I noticed that it was putting the newly created package into a new subdirectory of `output_dir`.  If I set `output_dir` to `./package_name` in the command line, and then also specified the package name as `package_name`, then the new package would be created in ```
```
./package_name/package_name
```
and the new module would be in 
```
./package_name/package_name/module_name
```
The behaviour I was expecting was that I could do
```
pieceofcake gh:OpenAstronomy/packaging_guide .
```
and then have the new package be put into `./package_name` as specified within the program instead of a subdirectory.
    
This commit makes pieceofcake pass `output_dir` directly to cookiecutter without checking if `output_dir` exists and without creating `output_dir`. This way, cookiecutter handles the directory checks & creation instead of pieceofcake.  Before this, `output_dir` was interpreted differentlyby pieceofcake and cookiecutter (partially because the name `output_dir` is ambiguous).
    
If a directory already exists called `package_name` within `output_dir`, then a `cookiecutter.exceptions.OutputDirExistsException` error is raised by cookiecutter.  An alternative possibility would be to catch this exception, but that would be helpful mostly if the cookiecutter error message isn't clear enough.

(By the way, thank you for creating this package!  It has made using cookiecutter easier to understand.)
